### PR TITLE
Fix content types

### DIFF
--- a/fastlane-plugin-upload_folder_to_s3.gemspec
+++ b/fastlane-plugin-upload_folder_to_s3.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'aws-sdk', '< 2'
+  spec.add_dependency 'mime-types', '~> 3.0'
 
   spec.add_development_dependency 'pry'     , '~> 0.10'
   spec.add_development_dependency 'bundler' , '~> 1.12'

--- a/lib/fastlane/plugin/upload_folder_to_s3/actions/upload_folder_to_s3_action.rb
+++ b/lib/fastlane/plugin/upload_folder_to_s3/actions/upload_folder_to_s3_action.rb
@@ -204,23 +204,13 @@ module Fastlane
       end
 
       def self.content_type_for_file(file)
-        file_extension = File.extname(file)
+        require 'mime/types'
 
-        extensions_to_type = {
-          ".html" => "text/html",
-          ".png"  => "image/png",
-          ".jpg"  => "text/jpeg",
-          ".gif"  => "image/gif",
-          ".log"  => "text/plain",
-          ".css"  => "text/css",
-          ".js"   => "application/javascript"
-        }
+        mime_type = MIME::Types.type_for(file).first
 
-        if extensions_to_type[file_extension].nil?
-          "application/octet-stream"
-        else
-          extensions_to_type[file_extension]
-        end
+        return "application/octet-stream" if mime_type.nil?
+
+        mime_type.content_type
       end
 
       @no_access_key_id_error_message     = "No Access key ID for upload_folder_to_s3 given, pass using `access_key_id: 'key_id'`"

--- a/lib/fastlane/plugin/upload_folder_to_s3/actions/upload_folder_to_s3_action.rb
+++ b/lib/fastlane/plugin/upload_folder_to_s3/actions/upload_folder_to_s3_action.rb
@@ -204,7 +204,7 @@ module Fastlane
       end
 
       def self.content_type_for_file(file)
-        require 'mime/types'
+        require "mime/types"
 
         mime_type = MIME::Types.type_for(file).first
 


### PR DESCRIPTION
Some of the content types were set wrongly, and things like SVG weren't supported at all. This PR introduces the mime-types gem which should always set an accurate content type